### PR TITLE
File Extension Detection and Commenting Feature  

### DIFF
--- a/include/CodeEditor.h
+++ b/include/CodeEditor.h
@@ -19,6 +19,8 @@ public:
     Mode mode = NORMAL;
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
+    QString getCurrentFileName() const { return currentFileName; }
+    void setCurrentFileName(const QString &fileName) { currentFileName = fileName; }
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;
@@ -31,6 +33,10 @@ private slots:
 
 private:
     QWidget *lineNumberArea;
+    QString currentFileName;
+    QString getFileExtension();
+    void addLanguageSymbol(QTextCursor &cursor, const QString commentSymbol);
+	void addComment();
 };
 
 #endif // CODEEDITOR_H

--- a/include/CodeEditor.h
+++ b/include/CodeEditor.h
@@ -24,9 +24,6 @@ public:
 signals:
     void statusMessageChanged(const QString &message);
 
-signals:
-    void statusMessageChanged(const QString &message);
-
 protected:
     void keyPressEvent(QKeyEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;

--- a/include/CodeEditor.h
+++ b/include/CodeEditor.h
@@ -18,8 +18,8 @@ public:
     Mode mode = NORMAL;
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
-    QString getCurrentFileName() const { return currentFileName; }
-    void setCurrentFileName(const QString &fileName) { currentFileName = fileName; }
+    QString getCurrentFileName() const { return m_currentFileName; }
+    void setCurrentFileName(const QString &fileName) { m_currentFileName = fileName; }
 
 signals:
     void statusMessageChanged(const QString &message);
@@ -35,10 +35,11 @@ private slots:
 
 private:
     QWidget *m_lineNumberArea;
-    QString currentFileName;
+    QString m_currentFileName;
+
     QString getFileExtension();
     void addLanguageSymbol(QTextCursor &cursor, const QString &commentSymbol);
     void commentSelection(QTextCursor &cursor, const QString &commentSymbol);
     void commentLine(QTextCursor &cursor, const QString &commentSymbol);
-	void addComment();
+    void addComment();
 };

--- a/include/CodeEditor.h
+++ b/include/CodeEditor.h
@@ -35,7 +35,9 @@ private:
     QWidget *lineNumberArea;
     QString currentFileName;
     QString getFileExtension();
-    void addLanguageSymbol(QTextCursor &cursor, const QString commentSymbol);
+    void addLanguageSymbol(QTextCursor &cursor, const QString &commentSymbol);
+    void commentSelection(QTextCursor &cursor, const QString &commentSymbol);
+    void commentLine(QTextCursor &cursor, const QString &commentSymbol);
 	void addComment();
 };
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -37,7 +37,6 @@ private:
                           const QKeySequence &shortcut, const QString &statusTip,
                           void (MainWindow::*slot)());
     CodeEditor *editor;
-    QString currentFileName;
     Syntax *syntax;
     Tree *tree;
 };

--- a/src/CodeEditor.cpp
+++ b/src/CodeEditor.cpp
@@ -26,6 +26,11 @@ void CodeEditor::keyPressEvent(QKeyEvent *event)
         moveCursor(QTextCursor::WordLeft, QTextCursor::KeepAnchor);
         return;
     }
+    if (event->modifiers() == Qt::ControlModifier && event->key() == Qt::Key_Slash)
+    {
+        addComment();
+        return;
+    }
 
     if (mode == NORMAL)
     {
@@ -54,6 +59,99 @@ void CodeEditor::keyPressEvent(QKeyEvent *event)
     else
     {
         QPlainTextEdit::keyPressEvent(event);
+    }
+}
+
+QString CodeEditor::getFileExtension()
+{
+    QString filePath = getCurrentFileName();
+    if (!QFile::exists(filePath))
+    {
+        return QString();
+    }
+
+    // Extract the file extension from the file path
+    return QFileInfo(filePath).suffix().toLower();
+}
+
+void CodeEditor::addLanguageSymbol(QTextCursor &cursor, const QString commentSymbol)
+{
+    // If text is selected, comment/uncomment selected text
+    if (cursor.hasSelection())
+    {
+        int start = cursor.selectionStart();
+        int end   = cursor.selectionEnd();
+
+        cursor.setPosition(start);
+        int startBlockNumber = cursor.blockNumber();
+        cursor.setPosition(end);
+        int endBlockNumber = cursor.blockNumber();
+
+        cursor.setPosition(start);
+        for (int i = startBlockNumber; i <= endBlockNumber; ++i)
+        {
+            cursor.movePosition(QTextCursor::StartOfLine);
+            QString lineText = cursor.block().text();
+
+            if (lineText.startsWith(commentSymbol))
+            {
+                cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, 3);
+                cursor.removeSelectedText();
+            }
+            else
+            {
+                cursor.insertText(commentSymbol + " ");
+            }
+
+            cursor.movePosition(QTextCursor::NextBlock);
+        }
+    }
+    else
+    {
+        // If no text is selected, comment/uncomment the current line
+        cursor.select(QTextCursor::LineUnderCursor);
+        QString lineText = cursor.selectedText();
+
+        if (lineText.startsWith(commentSymbol))
+        {
+            lineText.remove(0, 3);
+        }
+        else
+        {
+            lineText.prepend(commentSymbol + " ");
+        }
+
+        cursor.insertText(lineText);
+    }
+}
+
+void CodeEditor::addComment()
+{
+    QTextCursor cursor    = textCursor();
+    QString fileExtension = getFileExtension();
+    qDebug() << "File Extension:" << fileExtension;
+
+    if (fileExtension == "cpp" || fileExtension == "h" ||
+        fileExtension == "hpp" || fileExtension == "c" ||
+        fileExtension == "java" || fileExtension == "go" ||
+        fileExtension == "json")
+    {
+        addLanguageSymbol(cursor, "//");
+    }
+    else if (fileExtension == "py" || fileExtension == "yaml" ||
+             fileExtension == "yml" || fileExtension == "sh" ||
+             fileExtension == "bash")
+    {
+        addLanguageSymbol(cursor, "#");
+    }
+    else if (fileExtension == "sql")
+    {
+        addLanguageSymbol(cursor, "--");
+    }
+    else
+    {
+        qDebug() << "Unsupported file extension for commenting.";
+        return;
     }
 }
 

--- a/src/CodeEditor.cpp
+++ b/src/CodeEditor.cpp
@@ -5,6 +5,7 @@
 #include <QPainter>
 #include <QTextBlock>
 #include <QStatusBar>
+#include <QFileInfo>
 
 CodeEditor::CodeEditor(QWidget *parent)
     : QPlainTextEdit(parent),

--- a/src/CodeEditor.cpp
+++ b/src/CodeEditor.cpp
@@ -74,55 +74,65 @@ QString CodeEditor::getFileExtension()
     return QFileInfo(filePath).suffix().toLower();
 }
 
-void CodeEditor::addLanguageSymbol(QTextCursor &cursor, const QString commentSymbol)
+void CodeEditor::addLanguageSymbol(QTextCursor &cursor, const QString &commentSymbol)
 {
-    // If text is selected, comment/uncomment selected text
     if (cursor.hasSelection())
     {
-        int start = cursor.selectionStart();
-        int end   = cursor.selectionEnd();
-
-        cursor.setPosition(start);
-        int startBlockNumber = cursor.blockNumber();
-        cursor.setPosition(end);
-        int endBlockNumber = cursor.blockNumber();
-
-        cursor.setPosition(start);
-        for (int i = startBlockNumber; i <= endBlockNumber; ++i)
-        {
-            cursor.movePosition(QTextCursor::StartOfLine);
-            QString lineText = cursor.block().text();
-
-            if (lineText.startsWith(commentSymbol))
-            {
-                cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, 3);
-                cursor.removeSelectedText();
-            }
-            else
-            {
-                cursor.insertText(commentSymbol + " ");
-            }
-
-            cursor.movePosition(QTextCursor::NextBlock);
-        }
+        commentSelection(cursor, commentSymbol);
     }
     else
     {
-        // If no text is selected, comment/uncomment the current line
-        cursor.select(QTextCursor::LineUnderCursor);
-        QString lineText = cursor.selectedText();
+        commentLine(cursor, commentSymbol);
+    }
+}
+
+// Comment/uncomment the selected text or the current line
+void CodeEditor::commentSelection(QTextCursor &cursor, const QString &commentSymbol)
+{
+    int start = cursor.selectionStart();
+    int end   = cursor.selectionEnd();
+
+    cursor.setPosition(start);
+    int startBlockNumber = cursor.blockNumber();
+    cursor.setPosition(end);
+    int endBlockNumber = cursor.blockNumber();
+
+    cursor.setPosition(start);
+    for (int i = startBlockNumber; i <= endBlockNumber; ++i)
+    {
+        cursor.movePosition(QTextCursor::StartOfLine);
+        QString lineText = cursor.block().text();
 
         if (lineText.startsWith(commentSymbol))
         {
-            lineText.remove(0, 3);
+            cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, 3);
+            cursor.removeSelectedText();
         }
         else
         {
-            lineText.prepend(commentSymbol + " ");
+            cursor.insertText(commentSymbol + " ");
         }
 
-        cursor.insertText(lineText);
+        cursor.movePosition(QTextCursor::NextBlock);
     }
+}
+
+// Comment/uncomment the single current line
+void CodeEditor::commentLine(QTextCursor &cursor, const QString &commentSymbol)
+{
+    cursor.select(QTextCursor::LineUnderCursor);
+    QString lineText = cursor.selectedText();
+
+    if (lineText.startsWith(commentSymbol))
+    {
+        lineText.remove(0, 3);
+    }
+    else
+    {
+        lineText.prepend(commentSymbol + " ");
+    }
+
+    cursor.insertText(lineText);
 }
 
 void CodeEditor::addComment()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -223,6 +223,7 @@ void MainWindow::loadFileInEditor(const QString &filePath)
     editor->setPlainText(in.readAll());
     file.close();
 
+    editor->setCurrentFileName(filePath);
     currentFileName = filePath;
     setWindowTitle("CodeAstra ~ " + QFileInfo(filePath).fileName());
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -233,4 +233,5 @@ void MainWindow::loadFileInEditor(const QString &filePath)
 
     m_editor->setCurrentFileName(filePath);
     setWindowTitle("CodeAstra ~ " + QFileInfo(filePath).fileName());
+    emit m_editor->statusMessageChanged("File loaded successfully: " + QFileInfo(filePath).fileName());
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -170,13 +170,13 @@ void MainWindow::openFile()
 
 void MainWindow::saveFile()
 {
-    if (editor->getCurrentFileName().isEmpty())
+    if (m_editor->getCurrentFileName().isEmpty())
     {
         saveFileAs();
         return;
     }
 
-    QFile file(editor->getCurrentFileName());
+    QFile file(m_editor->getCurrentFileName());
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         QMessageBox::warning(this, "Error", "Cannot save file: " + file.errorString());
@@ -205,7 +205,7 @@ void MainWindow::saveFileAs()
 
     if (!fileName.isEmpty())
     {
-        editor->setCurrentFileName(fileName);
+        m_editor->setCurrentFileName(fileName);
         saveFile();
     }
 }
@@ -231,6 +231,6 @@ void MainWindow::loadFileInEditor(const QString &filePath)
     }
     file.close();
 
-    editor->setCurrentFileName(filePath);
+    m_editor->setCurrentFileName(filePath);
     setWindowTitle("CodeAstra ~ " + QFileInfo(filePath).fileName());
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -169,7 +169,7 @@ void MainWindow::openFile()
         }
         file.close();
 
-        currentFileName = fileName;
+        editor->setCurrentFileName(fileName);
 
         setWindowTitle("CodeAstra ~ " + QFileInfo(fileName).fileName());
     }
@@ -177,13 +177,13 @@ void MainWindow::openFile()
 
 void MainWindow::saveFile()
 {
-    if (currentFileName.isEmpty())
+    if (editor->getCurrentFileName().isEmpty())
     {
         saveFileAs();
         return;
     }
 
-    QFile file(currentFileName);
+    QFile file(editor->getCurrentFileName());
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         QMessageBox::warning(this, "Error", "Cannot save file: " + file.errorString());
@@ -205,7 +205,7 @@ void MainWindow::saveFileAs()
     QString fileName = QFileDialog::getSaveFileName(this, "Save File As");
     if (!fileName.isEmpty())
     {
-        currentFileName = fileName;
+        editor->setCurrentFileName(fileName);
         saveFile();
     }
 }
@@ -224,6 +224,5 @@ void MainWindow::loadFileInEditor(const QString &filePath)
     file.close();
 
     editor->setCurrentFileName(filePath);
-    currentFileName = filePath;
     setWindowTitle("CodeAstra ~ " + QFileInfo(filePath).fileName());
 }


### PR DESCRIPTION
This update improves the **CodeEditor** component by adding:  

1. **File Extension Detection**  
   - Implemented `getFileExtension()` to retrieve the file extension of the currently open file.  

2. **Code Commenting/Uncommenting**  
   - Added `addLanguageSymbol(QTextCursor &cursor, const QString commentSymbol)`  
     - Supports both single-line and multi-line selections.  
     - Automatically applies or removes the appropriate comment symbol based on the file type.  
   - Implemented `addComment()`, which:  
     - Detects the file extension.  
     - Applies the correct comment symbol for **C++, Java, Python, YAML, SQL, Bash, JSON, and Go** files.  

This feature improves the code editor by streamlining the process of toggling comments shortcuts, improving productivity, and ensuring language-specific syntax correctness. 🚀  

## Supported Comment Symbols in this PR

| File Type  | Comment Symbol |
|------------|---------------|
| C/C++, Java, Go, JSON | `//` |
| Python, YAML, Bash | `#` |
| SQL | `--` |

